### PR TITLE
Be resilient about invalid byte and replace them by Uchar.u_rep

### DIFF
--- a/lib/unstrctrd.ml
+++ b/lib/unstrctrd.ml
@@ -67,10 +67,10 @@ let safely_decode str = match of_string (str ^ "\r\n") with
   | Ok v -> v
   | Error (`Msg err) -> invalid_arg "%s" err (* XXX(dinosaure): should never occur! *)
 
-let to_utf_8_string lst =
+let to_utf_8_string ?(rep= Uutf.u_rep) lst =
   let buf = Buffer.create (List.length lst) in
   let iter = function
-    | `Invalid_char chr -> invalid_arg "Invalid byte: %02x" (Char.code chr)
+    | `Invalid_char _chr -> Uutf.Buffer.add_utf_8 buf rep
     | `d0 -> Buffer.add_char buf '\000'
     | `WSP wsp -> Buffer.add_string buf wsp
     | `OBS_NO_WS_CTL chr -> Buffer.add_char buf chr

--- a/lib/unstrctrd.mli
+++ b/lib/unstrctrd.mli
@@ -63,7 +63,7 @@ val replace_invalid_bytes : f:(invalid_char -> elt option) -> t -> t
 val of_list : elt list -> (t, [> error ]) result
 (** [of_list lst] tries to coerce [lst] to {!t}. It verifies that [lst] can not produce CRLF terminating token (eg. [[`CR; `LF]]). *)
 
-val to_utf_8_string : t -> string
+val to_utf_8_string : ?rep:Uchar.t -> t -> string
 (** [to_utf_8_string t] returns a valid UTF-8 string of [t]. The given [t] must not contain [`Invalid_char], you probably
     should clean-up with {!replace_invalid_bytes}. *)
 


### PR DESCRIPTION
Some emails are invalid due to the use of a certain encoding (`latin1` for example) at some invalid places. Instead to raise an error like: `Invalid byte`, we replace these bytes by `Uchar.u_rep`.