### PR TITLE
Correct " and double backslash inside comments.

### DIFF
--- a/lib/unstrctrd.ml
+++ b/lib/unstrctrd.ml
@@ -92,22 +92,21 @@ let without_comments lst =
           | true, _,  _ -> go stack ~escaped:false ~quoted_string acc r
           | false, _, 0 -> go stack ~escaped ~quoted_string:(not quoted_string) (value :: acc) r
           | false, false, _ -> go stack ~escaped ~quoted_string acc r
-          | false, true,  _ -> failwith "Should never happen")
+          | false, true,  _ -> assert false (* should never happen *))
         | 0x28 (* '(' *) ->
           ( match escaped, quoted_string, stack with
           | true,  _,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
           | true,  _,  _ -> go stack ~escaped:false ~quoted_string acc r
           | false, true , 0 -> go 0 ~escaped ~quoted_string (value :: acc) r
           | false, false, n -> go (succ n) ~escaped ~quoted_string acc r
-          | false, true,  _ -> failwith "Should never happen")
+          | false, true,  _ -> assert false (* should never happen *))
         | 0x29 (* ')' *) ->
           ( match escaped, quoted_string, stack with
           | true,  _,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
           | true,  _,  _ -> go stack ~escaped:false ~quoted_string acc r
           | false, true,  0 -> go 0 ~escaped ~quoted_string (value :: acc) r
           | false, false, n -> go (pred n) ~escaped ~quoted_string acc r
-          | false, true,  _ -> failwith "Should never happen"
-          )
+          | false, true,  _ -> assert false (* should never happen *))
         | 0x5c (* '\' *) ->
           ( match escaped, quoted_string, stack with
           | true,  _,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r

--- a/lib/unstrctrd.ml
+++ b/lib/unstrctrd.ml
@@ -88,45 +88,37 @@ let without_comments lst =
       ( match Uchar.to_int uchar with
         | 0x22 (* '"' *) ->
           ( match escaped, quoted_string, stack with
-          | true,  true,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
-          | true,  false, 0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
-          | false, true,  0 -> go stack ~escaped ~quoted_string:false (value :: acc) r
-          | false, false, 0 -> go stack ~escaped:false ~quoted_string:true (value :: acc) r
-          | true,  true,  _ -> go stack ~escaped:false ~quoted_string acc r
-          | true,  false, _ -> go stack ~escaped:false ~quoted_string acc r
-          | false, true,  _ -> go stack ~escaped ~quoted_string:false acc r
-          | false, false, _ -> go stack ~escaped ~quoted_string:true  acc r )
+          | true, _,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
+          | true, _,  _ -> go stack ~escaped:false ~quoted_string acc r
+          | false, _, 0 -> go stack ~escaped ~quoted_string:(not quoted_string) (value :: acc) r
+          | false, false, _ -> go stack ~escaped ~quoted_string acc r
+          | false, true,  _ -> failwith "Should never happen")
         | 0x28 (* '(' *) ->
           ( match escaped, quoted_string, stack with
-          | true,  true,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
-          | true,  false, 0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
-          | true,  true,  _ -> go stack ~escaped:false ~quoted_string acc r
-          | true,  false, _ -> go stack ~escaped:false ~quoted_string acc r
+          | true,  _,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
+          | true,  _,  _ -> go stack ~escaped:false ~quoted_string acc r
           | false, true , 0 -> go 0 ~escaped ~quoted_string (value :: acc) r
-          | false, true,  _ -> go stack ~escaped ~quoted_string acc r
-          | false, false, n -> go (succ n) ~escaped ~quoted_string acc r )
+          | false, false, n -> go (succ n) ~escaped ~quoted_string acc r
+          | false, true,  _ -> failwith "Should never happen")
         | 0x29 (* ')' *) ->
           ( match escaped, quoted_string, stack with
-          | true,  true,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
-          | true,  false, 0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
-          | true,  true,  _ -> go stack ~escaped:false ~quoted_string acc r
-          | true,  false, _ -> go stack ~escaped:false ~quoted_string acc r
+          | true,  _,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
+          | true,  _,  _ -> go stack ~escaped:false ~quoted_string acc r
           | false, true,  0 -> go 0 ~escaped ~quoted_string (value :: acc) r
-          | false, true,  _ -> go stack ~escaped ~quoted_string acc r
-          | false, false, n -> go (pred n) ~escaped ~quoted_string acc r )
+          | false, false, n -> go (pred n) ~escaped ~quoted_string acc r
+          | false, true,  _ -> failwith "Should never happen"
+          )
         | 0x5c (* '\' *) ->
           ( match escaped, quoted_string, stack with
-          | true,  true,  _ -> go stack ~escaped:false ~quoted_string (value :: acc) r
-          | true,  false, _ -> go stack ~escaped:false ~quoted_string (value :: acc) r
-          | false, true,  0 -> go 0 ~escaped:true ~quoted_string acc r
-          | false, false, 0 -> go 0 ~escaped:true ~quoted_string acc r
-          | false, _,     _ -> go stack ~escaped:true  ~quoted_string acc r )
+          | true,  _,  0 -> go stack ~escaped:false ~quoted_string (value :: acc) r
+          | true,  _,  _ -> go stack ~escaped:false ~quoted_string acc r
+          | false, _,  _ -> go stack ~escaped:true ~quoted_string acc r )
         | _ ->
           if stack > 0
           then go stack ~escaped:false ~quoted_string acc r
           else go stack ~escaped:false ~quoted_string (value :: acc) r )
     | value :: r ->
-      if stack > 0 
+      if stack > 0
       then go stack ~escaped:false ~quoted_string acc r
       else go stack ~escaped:false ~quoted_string (value :: acc) r in
   go 0 ~escaped:false ~quoted_string:false [] lst

--- a/test/test.ml
+++ b/test/test.ml
@@ -97,7 +97,8 @@ let () =
                   ; valid_unstructured_string_without_comment "(a\r\n (b \r\n c))\r\n" ""
                   ; valid_unstructured_string_without_comment "(a)(b)Hello(c)\r\n" "Hello"
                   ; valid_unstructured_string_without_comment "\\(Hello\\)\r\n" "(Hello)"
-                  ; valid_unstructured_string_without_comment "(Hi! \\) hidden)Hello\r\n" "Hello" ]
+                  ; valid_unstructured_string_without_comment "(Hi! \\) hidden)Hello\r\n" "Hello"
+                  ; valid_unstructured_string_without_comment "(Hi! \\\\)Hello\r\n" "Hello"]
     ; "complex", [ complex complex_0
                  ; complex complex_1
                  ; complex complex_2 ]
@@ -114,6 +115,6 @@ let () =
                  ; invalid_unstructured_string "Hello\r\n " ]
     ; "quoted-string", [ valid_unstructured_string_without_comment "Hello \"World\"!\r\n" "Hello \"World\"!"
                        ; valid_unstructured_string_without_comment "token=\":)\"\r\n" "token=\":)\""
-                       ; valid_unstructured_string_without_comment "(\")\")Hello\r\n" "Hello"
-                       ; valid_unstructured_string_without_comment "(\"(\")Hello\r\n" "Hello" ]
+                       ; valid_unstructured_string_without_comment "(\")Hello\r\n" "Hello"
+                       ; valid_unstructured_string_without_comment "(\\\")Hello\r\n" "Hello"]
     ]


### PR DESCRIPTION
Some changes to #10 PR to handle " and \\ inside comments and corresponding tests.